### PR TITLE
Adiciona regras de dano para defensores imobilizados, Adiciona item de reviver e Corrige tempo para começar a emboscada

### DIFF
--- a/app.py
+++ b/app.py
@@ -98,7 +98,7 @@ def main() -> None:
         callback=job_info_deploy_bot,
         when=timedelta(minutes=1),
         chat_id=MY_GROUP_ID,
-        name='JOB_ENEMY_ATTACK',
+        name='JOB_INFO_DEPLOY_BOT',
     )
 
     # Run the bot until the user presses Ctrl-C

--- a/bot/conversations/enemy.py
+++ b/bot/conversations/enemy.py
@@ -32,7 +32,7 @@ async def job_create_enemy_attack(context: ContextTypes.DEFAULT_TYPE):
 
     times = randint(1, 2) if is_boosted_day(now) else 1
     for i in range(times):
-        minutes_in_seconds = randint(1, 299) * 60
+        minutes_in_seconds = randint(1, 179) * 60
         print(
             f'JOB_CREATE_ENEMY_ATTACK() - {now}: '
             f'Evento de item inicia em {minutes_in_seconds // 60} minutos.'

--- a/bot/functions/player.py
+++ b/bot/functions/player.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, List
 
 from repository.mongo import PlayerModel
 
@@ -24,11 +24,14 @@ def get_player_name(_id: Any) -> str:
     return get_player_attribute_by_id(_id=_id, attribute='name')
 
 
-def get_player_name_by_chat_id(chat_id: int):
+def get_player_name_by_chat_id(chat_id: int, sort: bool = True) -> List[str]:
     player_model = PlayerModel()
     query = {'chat_ids': chat_id}
     fields = ['name']
     player_names = player_model.get_all(query=query, fields=fields)
+
+    if sort:
+        player_names.sort()
 
     if player_names:
         return player_names

--- a/repository/mongo/populate/consumable.py
+++ b/repository/mongo/populate/consumable.py
@@ -4,6 +4,7 @@ from rpgram.consumables import (
     CureConsumable,
     IdentifyingConsumable,
     HealingConsumable,
+    ReviveConsumable,
     XPConsumable,
 )
 from rpgram.consumables.heal import (
@@ -15,8 +16,15 @@ from rpgram.consumables.heal import (
     EPIC_HEALING_POTION_POWER,
     LEGENDARY_HEALING_POTION_POWER,
     MYTHIC_HEALING_POTION_POWER,
+    MINOR_REVIVE_POWER,
 )
-from rpgram.consumables.other import EPIC_PROFICIENCY_ELIXIR_POWER, LEGENDARY_PROFICIENCY_ELIXIR_POWER, MYTHIC_PROFICIENCY_ELIXIR_POWER, PROFICIENCY_ELIXIR_POWER, RARE_PROFICIENCY_ELIXIR_POWER
+from rpgram.consumables.other import (
+    EPIC_PROFICIENCY_ELIXIR_POWER,
+    LEGENDARY_PROFICIENCY_ELIXIR_POWER,
+    MYTHIC_PROFICIENCY_ELIXIR_POWER,
+    PROFICIENCY_ELIXIR_POWER,
+    RARE_PROFICIENCY_ELIXIR_POWER
+)
 from rpgram.enums import HealingConsumableEnum, RarityEnum, TurnEnum
 from rpgram.enums.debuff import (
     BLEEDING,
@@ -126,6 +134,18 @@ CONSUMABLES = [
         ),
         'rarity': RarityEnum.MYTHIC.name,
         'class': HealingConsumable,
+    },
+
+    # Revive Itens
+    {
+        'name': 'Minor Phoenix Feather',
+        'description': (
+            f'Revive personagem curando {MINOR_REVIVE_POWER} de HP.'
+        ),
+        'power': MINOR_REVIVE_POWER,
+        'weight': 0.50,
+        'rarity': RarityEnum.RARE.name,
+        'class': ReviveConsumable,
     },
 
     # Cure Potions

--- a/rpgram/conditions/debuff.py
+++ b/rpgram/conditions/debuff.py
@@ -360,3 +360,4 @@ if __name__ == '__main__':
     print(PetrifiedCondition())
     print(PoisoningCondition())
     print(SilenceCondition())
+    print(StunnedCondition() in IMMOBILIZED_DEBUFFS_NAMES)

--- a/rpgram/consumables/__init__.py
+++ b/rpgram/consumables/__init__.py
@@ -1,5 +1,6 @@
 from rpgram.consumables.consumable import Consumable
 from rpgram.consumables.heal import HealingConsumable
+from rpgram.consumables.heal import ReviveConsumable
 from rpgram.consumables.cure import CureConsumable
 from rpgram.consumables.other import IdentifyingConsumable
 from rpgram.consumables.other import XPConsumable

--- a/rpgram/consumables/heal.py
+++ b/rpgram/consumables/heal.py
@@ -17,6 +17,8 @@ EPIC_HEALING_POTION_POWER = 2500
 LEGENDARY_HEALING_POTION_POWER = 5000
 MYTHIC_HEALING_POTION_POWER = FULL_HEAL_VALUE
 
+MINOR_REVIVE_POWER = 1
+
 
 class HealingConsumable(Consumable):
     def __init__(
@@ -65,6 +67,56 @@ class HealingConsumable(Consumable):
             power=self.power,
             weight=super_dict['weight'],
             condition_name=self.condition.name if self.condition else None,
+            rarity=super_dict['rarity'],
+            usable=super_dict['usable'],
+            _id=super_dict['_id'],
+            created_at=super_dict['created_at'],
+            updated_at=super_dict['updated_at'],
+        )
+
+
+class ReviveConsumable(Consumable):
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        power: int,
+        weight: float,
+        rarity: Union[str, RarityEnum] = RarityEnum.COMMON,
+        usable: bool = True,
+        _id: Union[str, ObjectId] = None,
+        created_at: datetime = None,
+        updated_at: datetime = None,
+    ):
+        super().__init__(
+            name=name,
+            description=description,
+            weight=weight,
+            function=None,
+            battle_function=None,
+            rarity=rarity,
+            usable=usable,
+            _id=_id,
+            created_at=created_at,
+            updated_at=updated_at,
+        )
+        self.power = power
+
+    @property
+    def function(self) -> str:
+        return ('report = target.combat_stats.revive(self.power)')
+
+    @property
+    def battle_function(self) -> str:
+        return None
+
+    def to_dict(self):
+        super_dict = super().to_dict()
+        return dict(
+            name=super_dict['name'],
+            description=super_dict['description'],
+            power=self.power,
+            weight=super_dict['weight'],
             rarity=super_dict['rarity'],
             usable=super_dict['usable'],
             _id=super_dict['_id'],

--- a/rpgram/stats/stats_combat.py
+++ b/rpgram/stats/stats_combat.py
@@ -137,6 +137,7 @@ class CombatStats:
     def cure_hit_points(self, value: int) -> dict:
         if value == FULL_HEAL_VALUE:
             value = self.hit_points
+
         value = int(abs(value))
         old_hp = self.current_hit_points
         old_show_hp = self.show_hit_points
@@ -160,12 +161,26 @@ class CombatStats:
         }
 
     def revive(self, value: int = 1) -> dict:
+        if value == FULL_HEAL_VALUE:
+            value = self.hit_points
+
         value = -abs(int(value))
         old_hp = self.current_hit_points
         old_show_hp = self.show_hit_points
+        report = {
+            'old_hp': old_hp,
+            'old_show_hp': old_show_hp,
+            'cure': value,
+            'damaged': self.damaged,
+            'healed': self.healed,
+            'alive': self.alive,
+            'dead': self.dead,
+            'text': None
+        }
         if self.alive:
-            print(f'Não pode reviver um personagem vivo.')
-            return None
+            print('Não pode reviver um personagem vivo.')
+            report['text'] = 'Não pode reviver um personagem vivo.'
+            return report
         elif value < 0:
             print(f'Reviveu restaurando {-value} de HP.', end=' ')
         self.__damage = self.hit_points  # define dano para um valor máximo
@@ -178,7 +193,7 @@ class CombatStats:
         new_hp = self.current_hit_points
         new_show_hp = self.show_hit_points
         true_cure = (new_hp - old_hp)
-        return {
+        report.update({
             'old_hp': old_hp,
             'old_show_hp': old_show_hp,
             'new_hp': new_hp,
@@ -191,7 +206,9 @@ class CombatStats:
             'dead': self.dead,
             'action': 'Reviver',
             'text': f'HP: {old_show_hp} ››› {new_show_hp} ({true_cure}).'
-        }
+        })
+
+        return report
 
     def update(self) -> None:
         self.__boost_stats()
@@ -414,7 +431,7 @@ class CombatStats:
             text += f'`{HIT_POINT_INJURED_EMOJI_TEXT}: {self.show_hit_points} '
         else:
             text += f'`{HIT_POINT_FULL_EMOJI_TEXT}: {self.show_hit_points} '
-        
+
         if verbose:
             text += f'[{base_hp}{self.bonus_hit_points:+}]'
         text += f'`\n'

--- a/rpgram/status.py
+++ b/rpgram/status.py
@@ -10,6 +10,7 @@ from constant.text import TEXT_DELIMITER, TEXT_SEPARATOR_2
 from function.text import escape_basic_markdown_v2, remove_bold, remove_code
 
 from rpgram.conditions.condition import Condition
+from rpgram.conditions.debuff import IMMOBILIZED_DEBUFFS_NAMES
 from rpgram.constants.text import STATUS_EMOJI_TEXT
 from rpgram.enums.turn import TurnEnum
 
@@ -147,6 +148,26 @@ class Status:
         ]
 
         return reports
+
+    @property
+    def immobilized(self) -> bool:
+        return any(
+            condition in IMMOBILIZED_DEBUFFS_NAMES
+            for condition in self.__conditions
+        )
+
+    def immobilized_names(self) -> str:
+        '''Retorna os nomes das condições imobilizantes que o personagem 
+        possui. Caso não haja condições desse tipo, retorna uma exceção.'''
+        names = []
+        for condition in self.__conditions:
+            if condition in IMMOBILIZED_DEBUFFS_NAMES:
+                names.append(condition.full_name)
+
+        if not names:
+            raise ValueError('Status não tem condições imobilizadoras.')
+
+        return ', '.join(names)
 
     def battle_activate(self, char) -> List[dict]:
         reports = []


### PR DESCRIPTION
- Adiciona opção de ordenar os nomes dos jogadores
- Adiciona regras de dano para defensores imobilizados
- Um defensor imobilizado não pode esquivar.
- Um defensor imobilizado recebe o dano sem usar a defesa.
- O dano mínimo é de 10% do ataque boostado, caso seja superior a 90% da defesa base.
- Adiciona item de reviver
- Atualiza função de reviver
- Corrige tempo para começar a emboscada