### PR TITLE
Corrige resize_text quando a lista tem 2 elementos e Ordena os personagens pelo level

### DIFF
--- a/bot/conversations/enemy.py
+++ b/bot/conversations/enemy.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from math import ceil
+from operator import attrgetter
 from random import choice, randint, shuffle
 from time import sleep
 from typing import List, Union
@@ -1056,7 +1057,12 @@ async def add_xp_group(
     multiplied_level = (avg_level * sum_multiplier)
 
     full_text = ''
-    for char in char_list:
+    sorted_char_list = sorted(
+        char_list,
+        key=attrgetter('level', 'xp'),
+        reverse=True
+    )
+    for i, char in enumerate(sorted_char_list):
         level_diff = multiplied_level - (char.level * 2)
         base_xp = int(max(level_diff, 10) / total_allies)
         report_xp = add_xp(
@@ -1064,7 +1070,7 @@ async def add_xp_group(
             char=char,
             base_xp=base_xp,
         )
-        full_text += f'{report_xp["text"]}\n'
+        full_text += f'{i:02}: {report_xp["text"]}\n'
 
     full_text = create_text_in_box(
         text=full_text,

--- a/bot/conversations/enemy.py
+++ b/bot/conversations/enemy.py
@@ -865,8 +865,10 @@ def resize_text(
     '''
 
     text_list = text.split(spliter)
-    start_text_list = [text_list[0]]
-    final_text_list = start_text_list + text_list[-2:]
+    final_text_list = text_list
+    if len(text_list) > 3:
+        start_text_list = [text_list[0]]
+        final_text_list = start_text_list + text_list[-2:]
 
     return spliter.join(final_text_list).strip()
 

--- a/rpgram/characters/char_base.py
+++ b/rpgram/characters/char_base.py
@@ -354,6 +354,7 @@ class BaseCharacter:
     name: str = property(lambda self: self.__name)
     player_name: str = property(lambda self: self.__name)
     level: int = property(lambda self: self.__base_stats.level)
+    xp: int = property(lambda self: self.__base_stats.xp)
     _id: ObjectId = property(lambda self: self.__id)
     base_stats: BaseStats = property(fget=lambda self: self.__base_stats)
     combat_stats: CombatStats = property(fget=lambda self: self.__combat_stats)


### PR DESCRIPTION
- [Corrige resize_text quando a lista tem 2 elementos](https://github.com/Crissky/RPGRAM/commit/f96c700852ae6e6d588e0f7b2ba34ddd19e16557)
- [Ordena os personagens pelo level](https://github.com/Crissky/RPGRAM/commit/b623e3bb4c57ef1f0d6bae2a920479cebd209d9d) 
  - Ordena os personagens pelo level ao exibir ganho de xp de emboscada